### PR TITLE
[FIX] Check for sslConfig

### DIFF
--- a/src/modules/meteor/assets/templates/start.sh
+++ b/src/modules/meteor/assets/templates/start.sh
@@ -31,7 +31,7 @@ docker run \
   <% for(var option in logConfig.opts) { %>--log-opt <%= option %>=<%= logConfig.opts[option] %> <% } %>\
   <% for(var volume in volumes) { %>-v <%= volume %>:<%= volumes[volume] %> <% } %>\
   <% for(var args in docker.args) { %> <%= docker.args[args] %> <% } %>\
-  <% if(typeof sslConfig.autogenerate === "object")  { %> \
+  <% if(sslConfig && typeof sslConfig.autogenerate === "object")  { %> \
     -e "VIRTUAL_HOST=$HOSTNAME" \
     -e "LETSENCRYPT_HOST=<%= sslConfig.autogenerate.domains %>" \
     -e "LETSENCRYPT_EMAIL=<%= sslConfig.autogenerate.email %>" \


### PR DESCRIPTION
Previously, if there was no ssl section in deploy.js it was throwing an error:
```
[xxx.xxx.xxx.xxx] - Pushing the Startup Script
TypeError ejs:34
    32|   <% for(var volume in volumes) { %>-v <%= volume %>:<%= volumes[volume] %> <% } %>\
    33|   <% for(var args in docker.args) { %> <%= docker.args[args] %> <% } %>\
 >> 34|   <% if(typeof sslConfig.autogenerate === "object")  { %> \
    35|     -e "VIRTUAL_HOST=$HOSTNAME" \
    36|     -e "LETSENCRYPT_HOST=<%= sslConfig.autogenerate.domains %>" \
    37|     -e "LETSENCRYPT_EMAIL=<%= sslConfig.autogenerate.email %>" \

Cannot read property 'autogenerate' of undefined
```

I have added a check for sslConfig, so now it works even when there is no ssl section in deploy.js