### PR TITLE
[FIX] Wasn't working without ssl

### DIFF
--- a/src/modules/meteor/assets/templates/start.sh
+++ b/src/modules/meteor/assets/templates/start.sh
@@ -22,7 +22,11 @@ echo "Pulled <%= docker.image %>"
 docker run \
   -d \
   --restart=always \
+  <% if(sslConfig && typeof sslConfig.autogenerate === "object")  { %> \
   --expose=80 \
+  <% } else { %> \
+  --publish=$PORT:80 \
+  <% } %> \
   --volume=$BUNDLE_PATH:/bundle \
   --hostname="$HOSTNAME-$APPNAME" \
   --env-file=$ENV_FILE \


### PR DESCRIPTION
When we are using autogenerate, we are exposing 80 port.
When we are not using autogenerate, we should publish 80 port.